### PR TITLE
Remove .cfg condition for source interfaces.d

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -729,7 +729,7 @@ define network::interface (
             file_line { 'config_file_per_interface':
               ensure => $ensure,
               path   => '/etc/network/interfaces',
-              line   => 'source /etc/network/interfaces.d/*.cfg',
+              line   => 'source /etc/network/interfaces.d/*',
               notify => $network_notify,
             }
           }


### PR DESCRIPTION
On Debian, source everything in interfaces.d when
$network::config_file_per_interface is true instead
of only *.cfg